### PR TITLE
Remove Maven Signing

### DIFF
--- a/src/MavenUtils.ts
+++ b/src/MavenUtils.ts
@@ -117,17 +117,6 @@ export default class MavenUtils {
     return false
   }
 
-  public static isSigningRequired(repoUrl: string): string | void {
-    if (this.isLocalMavenRepo(repoUrl)) {
-      return ''
-    }
-    return `
-    signing {
-        useGpgCmd()
-        sign(publishing.publications.release)
-    }`
-  }
-
   public static createLocalMavenDirectoryIfDoesNotExist(repoUrl: string) {
     const dir = FILE_REGEX.exec(repoUrl)![1]
     if (!fs.existsSync(dir)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,6 @@ export default class MavenPublisher implements ContainerPublisher {
       path.join(containerPath, 'lib', 'build.gradle'),
       `
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
@@ -97,7 +96,6 @@ ${MavenUtils.targetRepositoryGradleStatement(url, {
   mavenPassword: extra && extra.mavenPassword,
   mavenUser: extra && extra.mavenUser,
 })}
-${MavenUtils.isSigningRequired(url)}
   }`
     )
 


### PR DESCRIPTION
Maven signing is not required for publishing to [MavenRepository](https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.tasks.PublishToMavenRepository.html)

P.S - This Repo is meant for publishing artifacts to local and repository. Signing is required only for publishing to MavenCentral.