### PR TITLE
Fix Maven Publisher Auth formatting

### DIFF
--- a/src/MavenUtils.ts
+++ b/src/MavenUtils.ts
@@ -53,15 +53,15 @@ export default class MavenUtils {
       if (isMavenUserVar || isMavenPwdVar) {
         authBlock = `
             credentials {
-                username = ${mavenUser!.slice(1,-1)}
-                password = ${mavenPassword!.slice(1, -1)}
+                username = "${mavenUser!.slice(1,-1)}"
+                password = "${mavenPassword!.slice(1, -1)}"
             }`
       } // Check if mavenUser or mavenPassword is to be appended as value in the authentication bean
       else if (mavenUser || mavenPassword) {
         authBlock = `
             credentials {
-                username = ${mavenUser}
-                password = ${mavenPassword}
+                username = "${mavenUser}"
+                password = "${mavenPassword}"
             }`
       }
       // --config '{"mavenUser": "myUser","mavenPassword": "myPassword"}'

--- a/test/MavenUtils-test.js
+++ b/test/MavenUtils-test.js
@@ -86,8 +86,8 @@ describe('MavenUtils', () => {
         maven {
             url = "${httpRepoUrl}"
             credentials {
-                username = ${mavenTestUser}
-                password = ${mavenTestPassword}
+                username = "${mavenTestUser}"
+                password = "${mavenTestPassword}"
             }
         }
     }`)
@@ -103,8 +103,8 @@ describe('MavenUtils', () => {
         maven {
             url = "${httpRepoUrl}"
             credentials {
-                username = ${mavenTestUser}
-                password = ${mavenTestPassword}
+                username = "${mavenTestUser}"
+                password = "${mavenTestPassword}"
             }
         }
     }`)
@@ -130,8 +130,8 @@ describe('MavenUtils', () => {
         maven {
             url = "${httpsRepoUrl}"
             credentials {
-                username = ${mavenTestUser}
-                password = ${mavenTestPassword}
+                username = "${mavenTestUser}"
+                password = "${mavenTestPassword}"
             }
         }
     }`)
@@ -147,8 +147,8 @@ describe('MavenUtils', () => {
         maven {
             url = "${httpsRepoUrl}"
             credentials {
-                username = ${mavenTestUser}
-                password = ${mavenTestPassword}
+                username = "${mavenTestUser}"
+                password = "${mavenTestPassword}"
             }
         }
     }`)


### PR DESCRIPTION
Fix maven credentials formatting - Require "" in username and pass.


## Actual
```
  repositories {
      maven {
          url = "${URL}"
          credentials {
              username = ${MAVENUSER}
              password = ${MAVENPass}
          }
      }
```

## Expected
```
  repositories {
      maven {
          url = "${URL}"
          credentials {
              username = "${MAVENUSER}"
              password = "${MAVENPass}"
          }
      }
```