### PR TITLE
Update deprecated classifier for gradle 8.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ export default class MavenPublisher implements ContainerPublisher {
 apply plugin: 'maven-publish'
 
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
 }
 


### PR DESCRIPTION
Gradle 7.x to 8.x migration 
classifier is deprecated and alternate archiveclassifier is used.
Refer - https://docs.gradle.org/current/userguide/upgrading_version_7.html#abstractarchivetask_api_cleanup