### PR TITLE
Update components.default to artifact bundleReleaseAar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ publishing {
                 groupId = "${extra.groupId}"
                 artifactId = "${extra.artifactId}"
                 version = "${containerVersion}"
-                from components.default
+                artifact bundleReleaseAar
                 artifact tasks.androidSourcesJar
             }
         }


### PR DESCRIPTION
Update components.default to **artifact bundleReleaseAar** to fix following issue during build

```
A problem occurred configuring project ':lib'.
> Could not get unknown property 'default' for SoftwareComponent container of type org.gradle.api.internal.component.DefaultSoftwareComponentContainer.
```
---

Fixes the compatibility issue with various Android Gradle Plugin versions
Provides a more reliable publishing mechanism that doesn't depend on components abstraction
Ensures consistency between your working compiled code and the source