### PR TITLE
Update release component to default component for gradle 8.x

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ publishing {
                 groupId = "${extra.groupId}"
                 artifactId = "${extra.artifactId}"
                 version = "${containerVersion}"
-                artifact bundleReleaseAar
+                from components.default
                 artifact tasks.androidSourcesJar
             }
         }


### PR DESCRIPTION
Starting with AGP 8.0:
Automatic component creation is disabled by default.
To publish, you need to manually configure component creation using the publishing DSL.
When configuring multiple variants for publishing, the component name is set to "default" by default, unless we specify a different name in the multipleVariants function call.
Therefore, if we were previously publishing the "release" variant using components.release, we would now refer to the component as components.default when using the multiple variants publishing approach with the default component name.

The change from components.release to components.default is a consequence of AGP 8.0 disabling automatic component creation and adopting a different naming convention for the default component created when publishing multiple variants using the publishing DSL.

Ref: https://developer.android.com/reference/tools/gradle-api/8.3/null/com/android/build/api/dsl/Publishing

Also fixes the pom file generation for dependencies not getting generated due to not using components